### PR TITLE
UninitializedPropertyAccessException 에러를 해결하라

### DIFF
--- a/kotlin-server/src/test/kotlin/com/bikemap/api/web/signin/ProjectConfig.kt
+++ b/kotlin-server/src/test/kotlin/com/bikemap/api/web/signin/ProjectConfig.kt
@@ -1,0 +1,8 @@
+package com.bikemap.api.web.signin
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringExtension
+
+class ProjectConfig : AbstractProjectConfig() {
+    override fun extensions() = listOf(SpringExtension)
+}


### PR DESCRIPTION
## 문제

SigninControllerTest 클래스에서 SigninService를 Mocking을 하려고 했습니다. 
Mocking을 하고 Service가 정상적으로 호출이 되는 것을 기대했는데 `kotlin.UninitializedPropertyAccessException: lateinit property signinService has not been initialized` 문제가 발생했습니다.

## 예시

```kotlin
    @MockkBean
    private lateinit var signinService: SigninService // mocking

    init {
        beforeEach {
            every {
                signinService.signin(signinData.email, signinData.password)
            } returns Authentication("", "")
        }
   }

```
SigninService에 모의 객체를 주입하고 signinService.signin 메서드가 Authentication을 리턴 받을 수 있게 합니다. 
Mocking 정상적으로 작동하면 SigninService가 호출이 되어야 합니다.
하지만 테스트 실행 하면 다음과 같은 에러가 발생합니다.
```bash
kotlin.UninitializedPropertyAccessException: lateinit property signinService has not been initialized
```

## 답변
공식문서에 따르면 Kotest를 Spring에서 사용하려면 `io.kotest.extensions:kotest-extensions-spring`을 테스트 컴파일 경로에 모듈을 추가해야 합니다. 
그리고 모든 테스트 클래스에 대해서 클래스별로 활성화를 해야 합니다.
이때 ProjectConfig 클래스를 생성해서 전역으로 활성화 해줘야 합니다.
```kotlin
class ProjectConfig : AbstractProjectConfig() {
   override fun extensions() = listOf(SpringExtension)
}
```
이 클래스가 생성되면 Spec 클래스를 상속받은 테스트 클래스가 Spring 테스트를 정상적으로 작동이 됩니다.

### 참고사항
- https://kotest.io/docs/extensions/spring.html#final-classes
