### PR TITLE
java.sql.SQLNonTransientConnectionException 에러를 해결하라

### DIFF
--- a/kotlin-server/README.md
+++ b/kotlin-server/README.md
@@ -1,1 +1,27 @@
 # Kotlin-Server
+
+> MacOS 기준으로 작성되었습니다.
+
+## 1-1. Docker 설치 및 DB 컨테이너 실행
+
+Docker 설치되어 있지 않으면 brew 통해 설치해줍니다.
+> brew install docker
+
+현재 Mariadb 버전은 10.8.3 입니다.
+> docker pull mariadb:[Tag]
+
+도커 실행 명령어는 다음과 같습니다.
+```shell
+docker run --name bike-map \
+-v $(pwd)/db:/var/lib/mysql \
+-e MYSQL_ROOT_PASSWORD=root1234 \
+-e MYSQL_DATABASE=bikemap \
+-d -p 3307:3306 mariadb:10.8.3 \
+--character-set-server=utf8mb4 \
+--collation-server=utf8mb4_unicode_ci
+```
+Docker container 접속하기
+> docker exec -i [컨테이너명 혹은 컨테이너 ID] mariadb -u root -p
+
+Docker 재실행하기
+> docker restart [컨테이너명 혹인 컨테이너 ID]


### PR DESCRIPTION
## 문제
SpringJPA 설정을 마치고 Docker의 Mariadb와 연결하려고 했습니다. 서버와 데이터베이스가 정상적으로 연결이 되었을 것을 기대했는데 다음과 같은 에러가 발생합니다.
```bash
java.sql.SQLNonTransientConnectionException: Socket fail to connect to host:address=(host=localhost)(port=3307)(type=primary). Connection refused
``` 

## 예시
application.yml 파일에는 `url: ${url:jdbc:mariadb://localhost:3307/bikemap}` 데이터베이스 경로 지정되어 있습니다.
터미널에서 `docker start [컨테이너 명]` 명령어를 입력합니다.
ServerApplication 실행합니다. 
다음과 같은 에러가 발생합니다.
```bash
java.sql.SQLNonTransientConnectionException: Socket fail to connect to host:address=(host=localhost)(port=3306)(type=primary). Connection refused
Caused by: java.net.ConnectException: Connection refused
```

## 답변
```bash
docker run --name bike-map \ 
-v $(pwd)/db:/var/lib/mysql \
-e MYSQL_ROOT_PASSWORD=root1234 \
-e MYSQL_DATABASE=bikemap \
-d -p 3307:8087 mariadb:10.8.3 \
--character-set-server=utf8mb4 \
--collation-server=utf8mb4_unicode_ci
```
Docker의 `-d -p 3307:8087 mariadb:10.8.3`  PORT 경로가 잘 못 되어 있었습니다.
PORT 경로를 `-d -p 3307:3306 mariadb:10.8.3 ` 변경해야 합니다.

경로가 올바르게 변경되었다면 정상적으로 작동합니다.

### 참고사항
- https://docs.docker.com/engine/reference/commandline/port/
- https://docs.docker.com/engine/reference/commandline/start/
- https://docs.docker.com/config/containers/container-networking/