### PR TITLE
JpaRepository을 상속하지 않고 Repository로 변경하라

### DIFF
--- a/kotlin-server/src/main/kotlin/com/bikemap/api/application/auth/service/SigninService.kt
+++ b/kotlin-server/src/main/kotlin/com/bikemap/api/application/auth/service/SigninService.kt
@@ -1,18 +1,23 @@
 package com.bikemap.api.application.auth.service
 
 import com.bikemap.api.application.auth.domain.Authentication
+import com.bikemap.api.application.user.domain.UserRepository
+import com.bikemap.api.application.user.execption.UserNotFoundException
 import com.bikemap.api.jwt.JwtProvider
 import org.springframework.stereotype.Service
 
 @Service
 class SigninService(
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val userRepository: UserRepository
 ) {
 
     fun signin(email: String, password: String): Authentication {
+        val user = userRepository.findByEmail(email) ?: throw UserNotFoundException(email)
+
         return Authentication(
-            jwtProvider.generateAccessToken(1),
-            jwtProvider.generateRefreshToken(1)
+            jwtProvider.generateAccessToken(user.id),
+            jwtProvider.generateRefreshToken(user.id)
         )
     }
 }

--- a/kotlin-server/src/main/kotlin/com/bikemap/api/application/user/domain/UserRepository.kt
+++ b/kotlin-server/src/main/kotlin/com/bikemap/api/application/user/domain/UserRepository.kt
@@ -1,8 +1,8 @@
 package com.bikemap.api.application.user.domain
 
-import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.Repository
 
-interface UserRepository : JpaRepository<User, Long> {
+interface UserRepository : Repository<User, Long> {
 
     /**
      * 사용자 이메일을 찾습니다.
@@ -11,4 +11,6 @@ interface UserRepository : JpaRepository<User, Long> {
      * @return 사용자를 찾으면 User 객체 아니면 null
      */
     fun findByEmail(email: String): User?
+
+    fun save(user: User): User
 }


### PR DESCRIPTION
Repository를 사용해야 하는 이유는 다음과 같습니다.
* 단위 테스트에서 리포지토리의 대역은 가짜 대역 사용 가능
* JpaRepository는 가짜 대역을 구현하기가 까다로움
* 명령 모델의 리포지토리는 필요한 메서드가 매우 적음
* JpaRepository를 상속하면 필요하지 않은 메서드를 오용할 가능성이 높음
* 조회 모델도 JpaRepository를 상속하지 않음
* Repository를 상속하고 필요할 때 메서드를 생성

정리
* JpaRepository를 상속하면 편하지만
* 단위 테스트에서 가짜 구현을 만들기 어려움
* CQRS에는 맞지 않음
* Repository를 상속하고 필요한 메서드만 추가

seeAlso
https://www.youtube.com/watch?v=MMH_ht8pf8U