### PR TITLE
Gradle에 JaCoCo 설정하기

### DIFF
--- a/kotlin-server/build.gradle.kts
+++ b/kotlin-server/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint-idea") version "11.0.0"
 
     id("org.asciidoctor.jvm.convert") version "3.3.2"
+
+    jacoco
 }
 
 group = "com.bikemap"
@@ -70,6 +72,31 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation:3.0.1")
 }
 
+// jacoco
+tasks {
+    jacocoTestReport {
+        reports {
+            html.required.set(true)
+            xml.required.set(false)
+            csv.required.set(false)
+        }
+        finalizedBy("jacocoTestCoverageVerification")
+    }
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                element = "CLASS"
+                limit {
+                    counter = "BRANCH"
+                    value = "COVEREDRATIO"
+                    minimum = "0.50".toBigDecimal()
+                }
+            }
+        }
+    }
+}
+
+// Restdoc
 tasks {
     withType<KotlinCompile> {
         kotlinOptions {
@@ -79,6 +106,7 @@ tasks {
     }
     withType<Test> {
         useJUnitPlatform()
+        finalizedBy("jacocoTestReport")
     }
     test {
         useJUnitPlatform()


### PR DESCRIPTION
**JaCoCo**는 Java 코드의 커버리지를 체크하는 라이브러리입니다. 
테스트코드를 작성하고 실행 시켜 그 커버리지 결과를 html, xml, csv와 같은 리포트로 확인 할 수 있습니다.
테스트 결과를 커버리지 기준을 설정 할 수 있고 커버리지 기준을 맞추지 못하면 배포를 하지 못하게 할 수 있습니다.

Javad와 Kotlin 코드를 Gradle 프로젝트에서 JaCoCo 설정을 합니다. 

**build.gradle**에 의존성 추가
```bash
plugins {
     jacoco
}

// jacoco
tasks {
    jacocoTestReport {
        reports {
            html.required.set(true)
            xml.required.set(false)
            csv.required.set(false)
        }
        finalizedBy("jacocoTestCoverageVerification")
    }
    jacocoTestCoverageVerification {
        violationRules {
            rule {
                element = "CLASS"
                limit {
                    counter = "BRANCH"
                    value = "COVEREDRATIO"
                    minimum = "0.50".toBigDecimal()
                }
            }
        }
    }
}
```

**실행** 커맨드 입력 명령어
```
 gradle test jacocoTestReport jacocoTestVoverageVerification 
```
`/build/reports/jacoco/test/html` 폴더 안에 `intex.html`파일이 생성이 됩니다.

**html** 파일 열기
```
open index.html
```
![api 2023-01-18 00-16-53](https://user-images.githubusercontent.com/68071599/212937091-1129930f-bfba-4066-bf1c-d8f01b106297.jpg)


## 참고 사항
- [JaCoCo specific task configuration](https://docs.gradle.org/current/userguide/jacoco_plugin.html#sec:jacoco_specific_task_configuration)
- [JacocoPluginExtension](https://docs.gradle.org/current/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.html#org.gradle.testing.jacoco.plugins.JacocoPluginExtension:reportsDirectory)
- [Gradle 프로젝트에 JaCoCo 설정하기](https://techblog.woowahan.com/2661/)
- [.isEnabled가 Deprecated 되어서 getRequired() 변경 ](https://gist.github.com/th-deng/2305025adb695aecad19ad02faa72d97)
