### PR TITLE
InvalidDataAccessApiUsageException를 해결하라

### DIFF
--- a/kotlin-server/src/main/kotlin/com/bikemap/api/application/user/domain/UserRepository.kt
+++ b/kotlin-server/src/main/kotlin/com/bikemap/api/application/user/domain/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.bikemap.api.application.user.domain
 
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.Repository
 
 interface UserRepository : Repository<User, Long> {
@@ -10,7 +11,6 @@ interface UserRepository : Repository<User, Long> {
      * @param email 사용자 이메일
      * @return 사용자를 찾으면 User 객체 아니면 null
      */
+    @Query("select u from User u where u.email.email = :email")
     fun findByEmail(email: String): User?
-
-    fun save(user: User): User
 }


### PR DESCRIPTION
## 문제
`POST/ http://localhost:8087/signin` 요청을 했습니다. 
AccesToken과 RefreshToken이 응답 받는 것을 기대했는데 `InvalidDataAccessApiUsageException` 문제가 발생했습니다.

## 예시
**Postman**에서 `POST/ http://localhost:8087/signin` 입력하고 Body에 다음과 같이 요청을 보냅니다.
```json
{
    "email": "test@email.com",
    "password": "bikemap1234567@@"
}
```
요청의 응답에러는 `500 Internal Server Error`가 발생합니다.
에러 메세지는 다음과 같습니다.
```bash
org.springframework.dao.InvalidDataAccessApiUsageException: Argument [test@email.com] of type [java.lang.String] did not match parameter type [com.bikemap.api.application.user.domain.Email
```

## 답변
요청한 타입의 유형과 `user.domain.Email`의 유형이 맞지 않아서 문제가 발생했습니다.

JPA에 `findByEmail`에 요청한 타입의 유형이 객체 Email에 맞도록 Query를 작성해야 합니다.
`@Query("select u from User u where u.email.email = :email")`
User의 Email 객체에 email을 호출해야만 정상적으로 작동이 가능합니다.

### 참고사항
